### PR TITLE
Include Secure ShellFish as supporting OSC 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Support
 - [Kitty](https://github.com/kovidgoyal/kitty/issues/68) since v0.19: [issue](https://github.com/kovidgoyal/kitty/issues/68)
 - [Konsole](https://konsole.kde.org/) since [Jul 2020](https://invent.kde.org/utilities/konsole/-/merge_requests/138) (disabled by default)
 - [mintty](http://mintty.github.io/) since [2.9.7](https://github.com/mintty/mintty/releases/tag/2.9.7) (2019-03-15)
+- [Secure ShellFish](https://secureshellfish.app/) since 2025-09-12
 - [Terminology](https://www.enlightenment.org/about-terminology) in Git since 2018-10-14, probably will be released in version 1.3
 - [Ultimate++ terminal widget](https://github.com/ismail-yilmaz/upp-components/tree/master/CtrlLib/Terminal) since Nov 2019
 - [VTE-based](https://wiki.gnome.org/Apps/Terminal/VTE): since 0.50[^1]


### PR DESCRIPTION
I'm the developer of Secure ShellFish that recently added support for OSC 8 links and would love to be added to the list.